### PR TITLE
ZF3 Support, Short array syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/composer.lock
+/vendor/
+/.idea/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 JhuZdtLoggerModule
 ==================
 
-A ZF2 module to log data using [Zend\Log](http://framework.zend.com/manual/2.1/en/modules/zend.log.overview.html) and write them to [ZendDeveloperTools](https://github.com/zendframework/ZendDeveloperTools) toolbar. If you already have a logger in your application (that is an instance of `Zend\Log\Logger`) it will integrate well with it so you still will only have to use your logger.
+A ZF3 module to log data using [Zend\Log](http://framework.zend.com/manual/2.1/en/modules/zend.log.overview.html) and write them to [ZendDeveloperTools](https://github.com/zendframework/ZendDeveloperTools) toolbar. If you already have a logger in your application (that is an instance of `Zend\Log\Logger`) it will integrate well with it so you still will only have to use your logger.
 ___
 
 Installation

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,19 @@
 {
     "name":         "jhuet/zdt-logger-module",
-    "description":  "A ZF2 module to log data using Zend_Log and write them to ZendDeveloperTools toolbar.",
+    "description":  "A ZF3 module to log data using Zend\\Log and write them to ZendDeveloperTools toolbar.",
     "type":         "library",
     "license":      "MIT",
-    "keywords":     ["zf2", "log", "zdt", "module"],
+    "keywords":     ["zf3", "log", "zdt", "module"],
     "homepage":     "https://github.com/jhuet/JhuZdtLoggerModule",
     "authors":      [ {
         "name":     "Jérémy Huet",
         "email":    "jeremy.huet@gmail.com",
         "homepage": "https://github.com/jhuet/"
     } ],
-    "minimum-stability": "dev",
     "require":      {
-        "php": ">=5.3.3",
         "zendframework/zend-log":  "2.*",
-        "zendframework/zend-developer-tools": "dev-master"
+        "zendframework/zend-developer-tools": "^1.1.0",
+        "zendframework/zend-servicemanager": "3.*"
     },
     "require-dev": {
         "atoum/atoum": "dev-master"

--- a/config/jhu-zdt-logger.global.php.dist
+++ b/config/jhu-zdt-logger.global.php.dist
@@ -5,7 +5,7 @@
  * If you have a ./config/autoload/ directory set up for your project, you can
  * drop this config file in it and change the values as you wish.
  */
-$settings = array(
+$settings = [
     /**
      * The logger that will be used. This module will only add a writer to it
      * so if you already have a logger in your application, you can set it here.
@@ -14,13 +14,13 @@ $settings = array(
      * and be an instance or extend Zend\Log\Logger.
      */
     'logger' => 'Zend\Log\Logger'
-);
+];
 
 /**
  * You do not need to edit below this line
  */
-return array(
-    'jhu' => array(
+return [
+    'jhu' => [
         'zdt_logger' => $settings
-    )
-);
+    ]
+];

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,29 +1,29 @@
 <?php
-return array(
-    'jhu' => array(
-        'zdt_logger' => array(
+return [
+    'jhu' => [
+        'zdt_logger' => [
             'logger' => 'Zend\Log\Logger'
-        ),
-    ),
+        ],
+    ],
 
     // zendframework/zend-developer-tools specific settings
 
-    'view_manager' => array(
-        'template_map' => array(
+    'view_manager' => [
+        'template_map' => [
             'zend-developer-tools/toolbar/jhu-zdt-logger' => __DIR__ . '/../view/zend-developer-tools/toolbar/jhu-zdt-logger.phtml',
-        ),
-    ),
+        ],
+    ],
 
-    'zenddevelopertools' => array(
-        'profiler' => array(
-            'collectors' => array(
+    'zenddevelopertools' => [
+        'profiler' => [
+            'collectors' => [
                 'jhu_zdt_logger' => 'Jhu\ZdtLoggerModule\Collector',
-            ),
-        ),
-        'toolbar' => array(
-            'entries' => array(
+            ],
+        ],
+        'toolbar' => [
+            'entries' => [
                 'jhu_zdt_logger' => 'zend-developer-tools/toolbar/jhu-zdt-logger',
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/src/Jhu/ZdtLoggerModule/Collector/ZendWriterCollector.php
+++ b/src/Jhu/ZdtLoggerModule/Collector/ZendWriterCollector.php
@@ -4,9 +4,7 @@ namespace Jhu\ZdtLoggerModule\Collector;
 
 use ZendDeveloperTools\Collector\CollectorInterface;
 use ZendDeveloperTools\Collector\AutoHideInterface;
-
 use Zend\Mvc\MvcEvent;
-
 use Jhu\ZdtLoggerModule\Writer\Stack as StackWriter;
 
 /**
@@ -24,7 +22,7 @@ class ZendWriterCollector implements CollectorInterface, AutoHideInterface
     const PRIORITY = 10;
 
     /**
-     * @var \Jhu\ZdtLoggerModule\Writer\Stack
+     * @var StackWriter
      */
     protected $zendWriter;
 
@@ -34,13 +32,13 @@ class ZendWriterCollector implements CollectorInterface, AutoHideInterface
     protected $name;
 
     /**
-     * @param Jhu\ZdtLoggerModule\Writer\Stack  $zendWriter
-     * @param string                            $name
+     * @param StackWriter  $zendWriter
+     * @param string       $name
      */
     public function __construct(StackWriter $zendWriter, $name)
     {
         $this->zendWriter = $zendWriter;
-        $this->name = (string) $name;
+        $this->name       = (string) $name;
     }
 
     /**

--- a/src/Jhu/ZdtLoggerModule/Module.php
+++ b/src/Jhu/ZdtLoggerModule/Module.php
@@ -43,7 +43,7 @@ class Module implements
     public function onBootstrap(EventInterface $e)
     {
         $application = $e->getParam('application');
-        $config = $application->getServiceManager()->get('Config');
+        $config      = $application->getServiceManager()->get('Config');
 
         // If the default logger is different and ZDT's toolbar is activated,
         // we initialize ours to add our functionalities
@@ -60,16 +60,16 @@ class Module implements
      */
     public function getAutoloaderConfig()
     {
-        return array(
-            'Zend\Loader\ClassMapAutoloader' => array(
+        return [
+            'Zend\Loader\ClassMapAutoloader' => [
                 __DIR__ . '/../../../autoload_classmap.php',
-            ),
-            'Zend\Loader\StandardAutoloader' => array(
-                'namespaces' => array(
+            ],
+            'Zend\Loader\StandardAutoloader' => [
+                'namespaces' => [
                     __NAMESPACE__ => __DIR__ . '/../../../src/' . __NAMESPACE__,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     /**
@@ -85,21 +85,21 @@ class Module implements
      */
     public function getServiceConfig()
     {
-        return array(
-            'invokables' => array(
-                'Jhu\ZdtLoggerModule\Writer'    => 'Jhu\ZdtLoggerModule\Writer\Stack',
-                'Zend\Log\Logger'               => 'Zend\Log\Logger'
-            ),
+        return [
+            'invokables' => [
+                'Jhu\ZdtLoggerModule\Writer'    => Writer\Stack::class,
+                'Zend\Log\Logger'               => \Zend\Log\Logger::class,
+            ],
 
-            'factories' => array(
+            'factories' => [
                 'Jhu\ZdtLoggerModule\Logger'    => new ServiceFactory\LoggerFactory(),
                 'Jhu\ZdtLoggerModule\Collector' => new ServiceFactory\CollectorFactory(),
                 'Jhu\ZdtLoggerModule\Options'   => new ServiceFactory\ModuleOptionsFactory(),
-            ),
+            ],
 
-            'aliases' => array(
+            'aliases' => [
                 'jhu.zdt_logger' => 'Jhu\ZdtLoggerModule\Logger',
-            ),
-        );
+            ],
+        ];
     }
 }

--- a/src/Jhu/ZdtLoggerModule/ServiceFactory/CollectorFactory.php
+++ b/src/Jhu/ZdtLoggerModule/ServiceFactory/CollectorFactory.php
@@ -2,9 +2,10 @@
 
 namespace Jhu\ZdtLoggerModule\ServiceFactory;
 
+use Interop\Container\ContainerInterface;
 use Jhu\ZdtLoggerModule\Collector\ZendWriterCollector;
-use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\ServiceManager\FactoryInterface;
+use Jhu\ZdtLoggerModule\Writer\Stack as StackWriter;
+use Zend\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Zdt Collector factory
@@ -22,10 +23,10 @@ class CollectorFactory implements FactoryInterface
      *
      * @return \Jhu\ZdtLoggerModule\Collector\ZendWriterCollector
      */
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        /* @var $writer \Jhu\ZdtLogger\Writer\Zdt */
-        $writer = $serviceLocator->get('Jhu\ZdtLoggerModule\Writer');
+        $writer = $container->get('Jhu\ZdtLoggerModule\Writer');
+        /* @var $writer StackWriter */
 
         return new ZendWriterCollector($writer, 'jhu_zdt_logger');
     }

--- a/src/Jhu/ZdtLoggerModule/ServiceFactory/LoggerFactory.php
+++ b/src/Jhu/ZdtLoggerModule/ServiceFactory/LoggerFactory.php
@@ -2,9 +2,11 @@
 
 namespace Jhu\ZdtLoggerModule\ServiceFactory;
 
+use Interop\Container\ContainerInterface;
 use Zend\Log\Logger;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Factory\FactoryInterface;
+use Jhu\ZdtLoggerModule\Writer\Stack as StackWriter;
 
 /**
  * Zdt Logger factory
@@ -20,22 +22,20 @@ class LoggerFactory implements FactoryInterface
     /**
      * {@inheritDoc}
      *
-     * @throws \InvalidArgumentException
-     *
-     * @return \Zend\Log\Logger
+     * @return Logger
      */
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $options = $serviceLocator->get('Jhu\ZdtLoggerModule\Options');
-        /* @var $logger \Zend\Log\Logger */
-        $logger = $serviceLocator->get($options->getLogger());
-
+        $options = $container->get('Jhu\ZdtLoggerModule\Options');
+        $logger  = $container->get($options->getLogger());
         if (! $logger instanceof Logger) {
-            throw new \InvalidArgumentException('`logger` option of JhuZdtLoggerModule has to be an instance or extend Zend\Log\Logger class.');
+            throw new ServiceNotCreatedException(
+                '`logger` option of JhuZdtLoggerModule has to be an instance or extend Zend\Log\Logger class.'
+            );
         }
 
-        /* @var $writer \Jhu\ZdtLogger\Writer\Zdt */
-        $writer = $serviceLocator->get('Jhu\ZdtLoggerModule\Writer');
+        $writer = $container->get('Jhu\ZdtLoggerModule\Writer');
+        /* @var $writer StackWriter */
 
         $logger->addWriter($writer);
 

--- a/src/Jhu/ZdtLoggerModule/ServiceFactory/ModuleOptionsFactory.php
+++ b/src/Jhu/ZdtLoggerModule/ServiceFactory/ModuleOptionsFactory.php
@@ -2,9 +2,9 @@
 
 namespace Jhu\ZdtLoggerModule\ServiceFactory;
 
+use Interop\Container\ContainerInterface;
 use Jhu\ZdtLoggerModule\Options;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\ServiceManager\Factory\FactoryInterface;
 
 /**
  * @since   0.1
@@ -18,12 +18,12 @@ class ModuleOptionsFactory implements FactoryInterface
     /**
      * {@inheritDoc}
      *
-     * @return \Jhu\ZdtLoggerModule\Options\ModuleOptions
+     * @return Options\ModuleOptions
      */
-    public function createService(ServiceLocatorInterface $services)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $config = $services->get('Configuration');
+        $config = $container->get('Configuration');
 
-        return new Options\ModuleOptions(isset($config['jhu']['zdt_logger']) ? $config['jhu']['zdt_logger'] : array());
+        return new Options\ModuleOptions(isset($config['jhu']['zdt_logger']) ? $config['jhu']['zdt_logger'] : []);
     }
 }

--- a/src/Jhu/ZdtLoggerModule/Writer/Stack.php
+++ b/src/Jhu/ZdtLoggerModule/Writer/Stack.php
@@ -20,17 +20,7 @@ class Stack extends AbstractWriter
      *
      * @var array
      */
-    protected $stack;
-
-    /**
-     * Constructor
-     */
-    public function __construct($options = null)
-    {
-        parent::__construct($options);
-
-        $this->stack = array();
-    }
+    protected $stack = [];
 
     /**
      * @return array

--- a/view/zend-developer-tools/toolbar/jhu-zdt-logger.phtml
+++ b/view/zend-developer-tools/toolbar/jhu-zdt-logger.phtml
@@ -2,11 +2,11 @@
     <div class="zdt-toolbar-preview">
         <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyBpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBXaW5kb3dzIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOjUwM0Y5OUE5NkUyODExRTJCNjY3OTA0MkYzMTY0OUY3IiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOjUwM0Y5OUFBNkUyODExRTJCNjY3OTA0MkYzMTY0OUY3Ij4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6NTAzRjk5QTc2RTI4MTFFMkI2Njc5MDQyRjMxNjQ5RjciIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6NTAzRjk5QTg2RTI4MTFFMkI2Njc5MDQyRjMxNjQ5RjciLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz4IVHtTAAABn0lEQVR42qyUzStFQRjG71znoGuhLHTJdyl2ysZKNk6SEBuyYWkhCyUrCxEpUnchO0VRFtbOStkpFuIvwC3HRlcXC4znvT3nNp3O/SjnrV8zZ2beZ2aemTNKax2LMuKxiMNyXTeD0gY/bNMGNeAOTIFxMAIS4DdEqwJkLSbFDbFvmQgo8AkWwQxYLWOBaUkcoKCIvYM5sMABG+CKYo/gLSAgk1YxPw3WLCb40QFGWb8AO6zLlltBj7FlRZsk/9lxnNxkliEmA/eZKKtZAl/sawJnoNnwrxK8gC6QxFnITm9MwRXgsL4MHoy+ba4+GHugnbupB9e+4CQFJbbAaSDxEtyCDL2u5YQnoA4MgQkwK2a2gV1eHRl0BBo5cwtt2aRXSfp4CI7FQ3j3ivID9IJpGXzARIlOJtpETm4QDIMUx8hNWPeXDu8aUJyDJ1BtMSFrXIOEYbrNCzvGNg/Mg3vDjn7QTfpU1P9y7lA8z9PGCv8vWCJ0yN9RqK/ka2OuXAXawvqif76ifw+L+OVvRYe0xwr05QWLna4qw9/8958AAwBMuWRXCzq8RAAAAABJRU5ErkJggg==" alt="ZF2 Logs">
         <span class="zdt-toolbar-info">
-            <?php echo $this->collector->getLogsCount(); ?> logs
+            <?php echo $this->collector->getLogsCount(); ?> log entries
         </span>
     </div>
     <div class="zdt-toolbar-detail">
-        <span class="zdt-toolbar-info zdt-toolbar-info-heading">ZF2 logs</span>
+        <span class="zdt-toolbar-info zdt-toolbar-info-heading">ZF3 log entries</span>
         <div class="zdt-toolbar-detail-inner zdt-toolbar-info-jhu-log">
             <?php foreach ($this->collector->getLogs() as $log): ?>
                 <hr />

--- a/view/zend-developer-tools/toolbar/jhu-zdt-logger.phtml
+++ b/view/zend-developer-tools/toolbar/jhu-zdt-logger.phtml
@@ -8,85 +8,68 @@
     <div class="zdt-toolbar-detail">
         <span class="zdt-toolbar-info zdt-toolbar-info-heading">ZF2 logs</span>
         <div class="zdt-toolbar-detail-inner zdt-toolbar-info-jhu-log">
-        <?php foreach ($this->collector->getLogs() as $log): ?>
-            <hr />
+            <?php foreach ($this->collector->getLogs() as $log): ?>
+                <hr />
 
-            <?php if (isset($log['timestamp'])): ?>
-                <span class="zdt-detail-label">Timestamp</span>
-                <span class="zdt-detail-value">
-                    <?php echo $log['timestamp']->format('Y-m-d H:i:s') ?>
-                </span>
-                <span class="clear"></span>
-            <?php endif ?>
+                <?php if (isset($log['timestamp'])): ?>
+                    <span class="zdt-toolbar-info">
+                        <span class="zdt-detail-label">Timestamp</span>
+                        <span class="zdt-detail-value">
+                        <?php echo $log['timestamp']->format('Y-m-d H:i:s') ?>
+                    </span>
+                    <span class="zdt-clear-jhu-log"></span>
+                <?php endif ?>
 
-            <?php if (isset($log['priority']) && isset($log['priorityName'])): ?>
-                <span class="zdt-detail-label">Priority</span>
-                <span class="zdt-detail-value">
-                    <?php echo $log['priorityName'] ?> (<?php echo $log['priority'] ?>)
-                </span>
-                <span class="clear"></span>
-            <?php endif ?>
+                <?php if (isset($log['priority']) && isset($log['priorityName'])): ?>
+                    <span class="zdt-toolbar-info">
+                        <span class="zdt-detail-label">Priority</span>
+                        <span class="zdt-detail-value">
+                        <?php echo $log['priorityName'] ?> (<?php echo $log['priority'] ?>)
+                    </span>
+                    <span class="zdt-clear-jhu-log"></span>
+                <?php endif ?>
 
-            <?php if (isset($log['message'])): ?>
-                <span class="zdt-detail-label">Message</span>
-                <span class="zdt-detail-value zdt-detail-value-jhu-log-message">
-                    <?php echo $log['message'] ?>
-                </span>
-                <span class="clear"></span>
-            <?php endif ?>
+                <?php if (isset($log['message'])): ?>
+                    <span class="zdt-toolbar-info">
+                        <span class="zdt-detail-label">Message</span>
+                        <span class="zdt-detail-value zdt-detail-value-jhu-log-message">
+                        <?php echo nl2br($log['message']) ?>
+                    </span>
+                    <span class="zdt-clear-jhu-log"></span>
+                <?php endif ?>
 
-            <?php if (isset($log['extra']) && !empty($log['extra'])): ?>
-                <span class="zdt-detail-label">Extra</span>
-                <span class="zdt-detail-value">
-                    <?php foreach($log['extra'] as $key => $value): ?>
-                        &nbsp;&nbsp;&nbsp;&nbsp;<?php echo $key ?> =&gt; <?php var_dump($value) ?><br/>
-                    <?php endforeach ?>
-                </span>
-                <span class="clear"></span>
-            <?php endif ?>
-        <?php endforeach ?>
+                <?php if (isset($log['extra']) && !empty($log['extra'])): ?>
+                    <span class="zdt-toolbar-info">
+                        <span class="zdt-detail-label">Extra</span>
+                        <span class="zdt-detail-value">
+                        <?php foreach($log['extra'] as $key => $value): ?>
+                            &nbsp;&nbsp;&nbsp;&nbsp;<?php echo $key ?> =&gt; <?php var_dump($value) ?><br/>
+                        <?php endforeach ?>
+                    </span>
+                    <span class="zdt-clear-jhu-log"></span>
+                <?php endif ?>
+            <?php endforeach ?>
         </div>
     </div>
 </div>
-<style>
-/*
+<style type="text/css">
+    .zdt-clear-jhu-log {
+        clear: both;
+        display: block;
+    }
 
-.zdt-toolbar-entry .zdt-toolbar-detail .ddt-detail-query {
+    .zdt-toolbar-entry .zdt-toolbar-detail .zdt-toolbar-info-jhu-log {
+        font-size: 11px;
+        max-width: 600px;
+        width: 600px;
+        max-height: 300px;
+        overflow-y: auto;
+        overflow-x: auto;
+    }
 
-    white-space: normal;
-    width: 400px;
-}
-
-.zdt-toolbar-entry .zdt-toolbar-detail .ddt-detail-query .highlight {
-
-    color: #80DC09;
-    font-weight: bold;
-}
-*/
-.zdt-toolbar-entry .zdt-toolbar-info .clear {
-
-    clear: both;
-    display: block;
-}
-
-.zdt-toolbar-entry .zdt-toolbar-detail .zdt-toolbar-info-jhu-log {
-
-    font-size: 11px;
-    max-width: 600px;
-    witdh: 600px;
-    max-height: 300px;
-    overflow-y: auto;
-    overflow-x: auto;
-}
-
-/*.zdt-toolbar-info .zdt-detail-value-jhu-log-message {
-    white-space: normal;
-}*/
-
-.zdt-toolbar-entry .zdt-toolbar-detail hr {
-
-    border: 0;
-    border-top: 1px solid #80DC09;
-    clear: both;
-}
+    .zdt-toolbar-entry .zdt-toolbar-detail hr {
+        border: 0;
+        border-top: 1px solid #80DC09;
+        clear: both;
+    }
 </style>


### PR DESCRIPTION
I've made the logger module compatible with ZF3 and cleaned up some code.

The view script in particular was broken because the span.zdt-toolbar-info was missing even though the closing tag was still there?

Ive edited the composer.json as well to allow consumers to use stable version.
